### PR TITLE
Fix serval bugs, such as compile error & safe string assignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ OutputBinder.o: OutputBinder.hpp OutputBinder.cpp MySqlPreparedStatement.hpp
 
 libmysqlcpp.so: MySql.o MySql.hpp MySqlException.o MySqlException.hpp \
 	MySqlPreparedStatement.o InputBinder.hpp OutputBinder.o OutputBinder.hpp
-	$(CXX) $(CXXFLAGS) $(SHAREDFLAGS) -W1,-soname,libmysqlcpp.so \
+	$(CXX) $(CXXFLAGS) $(SHAREDFLAGS) -Wl,-soname,libmysqlcpp.so \
 		MySql.o MySqlException.o MySqlPreparedStatement.o OutputBinder.o \
 		-o libmysqlcpp.so
 

--- a/MySqlException.hpp
+++ b/MySqlException.hpp
@@ -15,8 +15,8 @@ class MySqlException : public std::exception {
         explicit MySqlException(const MySqlPreparedStatement& statement);
         ~MySqlException() noexcept;
 
-        MySqlException& operator=(const MySqlException&) = delete;
-        MySqlException& operator=(MySqlException&&) = delete;
+//        MySqlException& operator=(const MySqlException&) = delete;
+//        MySqlException& operator=(MySqlException&&) = delete;
 
         const char* what() const noexcept;
 

--- a/OutputBinder.hpp
+++ b/OutputBinder.hpp
@@ -334,9 +334,9 @@ class OutputBinderResultSetter<std::string> {
             if (*bind.is_null) {
                 throw MySqlException(NULL_VALUE_ERROR_MESSAGE);
             }
-            // Strings have an operator= for char*, so we can skip the
-            // lexical_cast and just call this directly
-            *value = static_cast<const char*>(bind.buffer);
+            // bind.buffer may not terminated with '\0', so we should use
+            // string::assign() and specify the column length.
+            value->assign(static_cast<const char*>(bind.buffer), *(bind.length));
         }
 };
 


### PR DESCRIPTION
I wonder to know why you delete copy ctor & move ctor in MySqlException ? and it cause a compile error below.

```
In file included from MySql.hpp:19:0,
                 from examples.cpp:1:
OutputBinder.hpp: In static member function ‘static void OutputBinderPrivate::OutputBinderResultSetter<signed char>::setResult(int8_t*, const MYSQL_BIND&)’:
OutputBinder.hpp:311:62: error: use of deleted function ‘MySqlException::MySqlException(const MySqlException&)’
                 throw MySqlException(NULL_VALUE_ERROR_MESSAGE); \
```

Thanks for you work.
